### PR TITLE
Upgrade to rom 5

### DIFF
--- a/lib/rom/yesql/relation.rb
+++ b/lib/rom/yesql/relation.rb
@@ -49,7 +49,6 @@ module ROM
       def self.inherited(klass)
         super
         klass.extend(ClassInterface)
-        define_query_methods(klass, queries[klass.dataset] || {})
       end
 
       # Extends provided klass with query methods

--- a/lib/rom/yesql/relation/class_interface.rb
+++ b/lib/rom/yesql/relation/class_interface.rb
@@ -14,10 +14,9 @@ module ROM
         #
         # @api public
         def dataset(name = Undefined)
-          return @dataset if name == Undefined
-          @dataset = name
+          name = relation_name.to_sym if name == Undefined
           define_query_methods(self, Relation.queries[name] || {})
-          @dataset
+          ->(*) { self }
         end
       end
     end

--- a/rom-yesql.gemspec
+++ b/rom-yesql.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rom", "~> 3.2"
-  spec.add_runtime_dependency "dry-core", "~> 0.2", ">= 0.2.4"
-  spec.add_runtime_dependency "sequel", "~> 4.27"
+  spec.add_runtime_dependency "rom", "~>5"
+  spec.add_runtime_dependency "dry-core", "~>0.4"
+  spec.add_runtime_dependency "sequel", "~>5"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'ROM / Yesql' do
 
   let(:report_queries) { { all_users: 'SELECT * FROM users ORDER BY %{order}' } }
 
-  let(:users) { container.relation(:users) }
-  let(:tasks) { container.relation(:tasks) }
-  let(:reports) { container.relation(:reports) }
+  let(:users) { container.relations[:users] }
+  let(:tasks) { container.relations[:tasks] }
+  let(:reports) { container.relations[:reports] }
 
   before do
     configuration.relation(:users)

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'ROM / Yesql' do
 
     module Test
       class Reports < ROM::Relation[:yesql]
-        dataset :reports
+        schema :reports, infer: true
       end
     end
 


### PR DESCRIPTION
🔧 Upgrades to Rom v5, modifying the `dataset` method in the YeSQL relation to correctly define the query methods and to return `self` per the new requirements for Rom v5.
🔪 Removes the unnecessary definition of query methods in the class initialisation
📝 Defines the `schema` correctly for classes derived from a YeSQL relation
💚 We have a green test suite, but have not been able to test this directly in a Rom5-based YeSQL project.
⚠️ This does not fix rubocop warnings, as was unsure of the requirements for the project.
📜 No documentation changes have been made either, e.g. to explain the new requirements for a YeSQL relation.
📫 Closes #14