### PR TITLE
Bump dry core and cater for running under Ruby 3

### DIFF
--- a/lib/rom/yesql/gateway.rb
+++ b/lib/rom/yesql/gateway.rb
@@ -71,7 +71,7 @@ module ROM
       #   @option :query_proc [Proc]
       #
       # @api public
-      def initialize(*)
+      def initialize(*, **)
         super
         @connection = Sequel.connect(uri, options)
         @queries = @queries.merge(load_queries(path)).freeze

--- a/rom-yesql.gemspec
+++ b/rom-yesql.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rom", "~>5"
-  spec.add_runtime_dependency "dry-core", "~>0.4"
+  spec.add_runtime_dependency "dry-core", "~>1.0"
   spec.add_runtime_dependency "sequel", "~>5"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/integration/adapter_spec.rb
+++ b/spec/integration/adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "ROM / Yesql" do
   let(:container) { ROM.container(configuration) }
 
   let!(:configuration) do
-    ROM::Configuration.new(:yesql, [uri, path: path, queries: {reports: report_queries}])
+    ROM::Configuration.new(:yesql, *[uri, path: path, queries: {reports: report_queries}])
   end
 
   let(:report_queries) { {all_users: "SELECT * FROM users ORDER BY %{order}"} }


### PR DESCRIPTION
💎 Bumps dry-core to a later version.
🔧 Caters for running under Ruby 3.
📝 Both of these are required for us to upgrade to Ruby 3 and continue to use rom-yesql. 

I would appreciate it if these minor changes can be merged and a new version deployed to Rubygems so we can continue to use this in our project under ruby 3.

